### PR TITLE
Correct process.ARGV. Should be process.argv.

### DIFF
--- a/src/paige.coffee
+++ b/src/paige.coffee
@@ -23,7 +23,7 @@ configuration = {
 # Read our configuration file.
 read_config = (callback) ->
   filename = "paige.config"
-  filename = process.ARGV[2] if process.ARGV[2]?
+  filename = process.argv[2] if process.argv[2]?
   fs.readFile filename, "utf-8", (error, data) ->
     if error
       console.log "\nCould not find a configuration file. (default: ./paige.config)"


### PR DESCRIPTION
See http://nodejs.org/docs/v0.5.10/api/process.html#process.argv

Example output before change:

```
node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
TypeError: Cannot read property '2' of undefined
    at /usr/local/lib/node_modules/paige/lib/paige.js:25:21
    at Object.<anonymous> (/usr/local/lib/node_modules/paige/lib/paige.js:144:3)
    at Object.<anonymous> (/usr/local/lib/node_modules/paige/lib/paige.js:153:4)
    at Module._compile (module.js:432:26)
    at Object..js (module.js:450:10)
    at Module.load (module.js:351:31)
    at Function._load (module.js:310:12)
    at Module.require (module.js:357:17)
    at require (module.js:368:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/paige/bin/paige:7:1)
```
