### PR TITLE
Replacing github syntax highlighted code blocks with showdown friendly pre tags

### DIFF
--- a/lib/paige.js
+++ b/lib/paige.js
@@ -1,14 +1,23 @@
 (function() {
-  var check_for_rocco, clean_file_extension, clean_path_names, config_template, configuration, copy_image, ensure_directory, events, exec, fs, get_subfiles, mdown_template, path, process_config, process_html_file, read_config, rocco, showdown, spawn, subfiles, template, _, _ref;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+  var check_for_rocco, clean_file_extension, clean_path_names, config_template, configuration, copy_image, ensure_directory, events, exec, fs, get_subfiles, mdown_template, path, process_config, process_html_file, read_config, rocco, showdown, spawn, subfiles, template, _, _ref,
+    _this = this;
+
   _ = require("underscore");
+
   fs = require('fs');
+
   path = require('path');
+
   showdown = require('./../vendor/showdown').Showdown;
+
   _ref = require('child_process'), spawn = _ref.spawn, exec = _ref.exec;
+
   events = require('events');
+
   rocco = require('./rocco.js');
+
   subfiles = [];
+
   configuration = {
     "title": "Untitled",
     "content_file": "README.mdown",
@@ -19,12 +28,11 @@
     "background": "bright_squares",
     "output": "docs"
   };
+
   read_config = function(callback) {
     var filename;
     filename = "paige.config";
-    if (process.ARGV[2] != null) {
-      filename = process.ARGV[2];
-    }
+    if (process.argv[2] != null) filename = process.argv[2];
     return fs.readFile(filename, "utf-8", function(error, data) {
       var config;
       if (error) {
@@ -34,47 +42,44 @@
       } else {
         config = JSON.parse(data);
         process_config(config);
-        if (callback) {
-          return callback(config);
-        }
+        if (callback) return callback(config);
       }
     });
   };
+
   process_config = function(config) {
-    if (config == null) {
-      config = {};
-    }
+    if (config == null) config = {};
     return _.map(config, function(value, key, list) {
-      if (config[key] != null) {
-        return configuration[key] = value;
-      }
+      if (config[key] != null) return configuration[key] = value;
     });
   };
+
   ensure_directory = function(dir, callback) {
     return exec("mkdir -p " + dir, function() {
       return callback();
     });
   };
+
   copy_image = function() {
     var desired_image;
     desired_image = fs.readFileSync(__dirname + ("/../resources/" + configuration.background + ".png"));
     return fs.writeFile("" + configuration.output + "/bg.png", desired_image);
   };
+
   process_html_file = function() {
     var clean_subfiles, source, subfiles_names;
     source = configuration.content_file;
     if (configuration.include_index) {
       subfiles_names = clean_file_extension(subfiles);
     }
-    if (configuration.include_index) {
-      clean_subfiles = clean_path_names(subfiles);
-    }
+    if (configuration.include_index) clean_subfiles = clean_path_names(subfiles);
     return fs.readFile(source, "utf-8", function(error, code) {
       var content_html, html;
       if (error) {
         console.log("\nThere was a problem reading your the content file: " + source);
         throw error;
       } else {
+        code = code.replace(/```\w*\n?([^```]*)```/gm, '<pre>\n$1</pre>');
         content_html = showdown.makeHtml(code);
         html = mdown_template({
           content_html: content_html,
@@ -90,26 +95,24 @@
       }
     });
   };
+
   template = function(str) {
     return new Function('obj', 'var p=[],print=function(){p.push.apply(p,arguments);};' + 'with(obj){p.push(\'' + str.replace(/[\r\t\n]/g, " ").replace(/'(?=[^<]*%>)/g, "\t").split("'").join("\\'").split("\t").join("'").replace(/<%=(.+?)%>/g, "',$1,'").split('<%').join("');").split('%>').join("p.push('") + "');}return p.join('');");
   };
-  get_subfiles = __bind(function(callback) {
+
+  get_subfiles = function(callback) {
     var count, find_files;
     count = 0;
-    find_files = __bind(function(file, total) {
+    find_files = function(file, total) {
       var f_file, f_path;
       f_path = file.substr(0, file.lastIndexOf('/') + 1);
       f_file = file.substr(file.lastIndexOf('/') + 1);
       return exec("find ./" + f_path + " -name '" + f_file + "' -print", function(error, stdout, stderr) {
         count++;
         subfiles = _.uniq(_.union(subfiles, stdout.trim().split("\n")));
-        if (count >= total) {
-          if (callback) {
-            return callback();
-          }
-        }
+        if (count >= total) if (callback) return callback();
       });
-    }, this);
+    };
     if (_.isArray(configuration.docco_files)) {
       return _.each(configuration.docco_files, function(file) {
         return find_files(file, configuration.docco_files.length);
@@ -117,7 +120,8 @@
     } else if (_.isString(configuration.docco_files)) {
       return find_files(configuration.docco_files, 1);
     }
-  }, this);
+  };
+
   clean_path_names = function(names) {
     var clean_names;
     clean_names = [];
@@ -126,6 +130,7 @@
     });
     return clean_names;
   };
+
   clean_file_extension = function(names) {
     var clean_names;
     clean_names = [];
@@ -134,13 +139,15 @@
     });
     return clean_names;
   };
+
   check_for_rocco = function() {
-    if (configuration.docco_files != null) {
-      return rocco(subfiles, configuration);
-    }
+    if (configuration.docco_files != null) return rocco(subfiles, configuration);
   };
+
   mdown_template = template(fs.readFileSync(__dirname + '/../resources/paige.jst').toString());
+
   config_template = fs.readFileSync(__dirname + '/../resources/paige.config').toString();
+
   read_config(function(config) {
     return ensure_directory(configuration.output, function() {
       return get_subfiles(function() {
@@ -150,4 +157,5 @@
       });
     });
   });
+
 }).call(this);

--- a/src/paige.coffee
+++ b/src/paige.coffee
@@ -66,6 +66,9 @@ process_html_file = ->
       console.log "\nThere was a problem reading your the content file: #{source}"
       throw error
     else
+      # replace ``` block with <pre> tags
+      code = code.replace /```\w*\n?([^```]*)```/gm, '<pre>\n$1</pre>'
+    
       content_html = showdown.makeHtml code
       html = mdown_template {
         content_html:     content_html,


### PR DESCRIPTION
Firstly - thanks for Paige, exactly what I was after :) 

One thing I did have in my README files though was a lot of the github flavoured syntax highlighting which was not getting handled well by the showdown processor.  So I popped a regex to replace those with pre tags prior to processing.

I don't usually code in coffeescript though, so it's probably worth checking that no brackets slipped in ;)
